### PR TITLE
fix(estdlib): isClass does not always recognize minified classes

### DIFF
--- a/packages/estdlib/src/core.ts
+++ b/packages/estdlib/src/core.ts
@@ -123,7 +123,7 @@ export function isPromise(obj: any): obj is Promise<any> {
  */
 export function isClass(obj: any): obj is ClassType<any> {
     if ('function' === typeof obj) {
-        return obj.toString().startsWith('class ');
+        return obj.toString().startsWith('class ') || obj.toString().startsWith('class{');
     }
 
     return false;


### PR DESCRIPTION
**Issue**: `isClass` fails on certain types of minified builds (even when mangling is disabled).
**Cause**: some minified builds minimize into code that does not have a space between `class {`, which causes the original check to fil.
**Fix**: add a fallback check that allows `class{` as well.